### PR TITLE
docs: fix installation clone commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,8 +21,8 @@ Stelle sicher, dass folgende Software installiert ist
 ### 1. Repository klonen
 
 ```bash
-git clone https://github.com/daonware-it/blog-system.git
-cd blog-system/homepage
+git clone https://github.com/daonware-it/nextjs-blog.git
+cd nextjs-blog/blog-page
 ```
 
 ----


### PR DESCRIPTION
## Summary
- update repository URL in installation docs
- adjust cd command to new project path

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ddaf51a1c832eadf73496d2db7b36