### PR TITLE
fix: import useEffect in Navbar

### DIFF
--- a/blog-page/src/components/Navbar.tsx
+++ b/blog-page/src/components/Navbar.tsx
@@ -1,4 +1,8 @@
-import React, { useEffect } from "react";
+import { useEffect, useState } from "react";
+import navbarStyles from "./navbar.module.css";
+import { useSession, signOut } from "next-auth/react";
+import type { Session } from "next-auth";
+
 // Google Fonts für moderne Schrift überall einbinden
 function useGlobalFonts() {
   useEffect(() => {
@@ -13,12 +17,6 @@ function useGlobalFonts() {
     }
   }, []);
 }
-import navbarStyles from "./navbar.module.css";
-import { useSession, signOut } from "next-auth/react";
-import type { Session } from "next-auth";
-
-
-import { useState } from "react";
 
 export default function Navbar() {
   useGlobalFonts();


### PR DESCRIPTION
## Summary
- ensure Navbar imports React hooks correctly

## Testing
- `npx tsc --noEmit` *(fails: Property 'id' does not exist on type)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dd9f543b0832eb8e4eb8ec5e44c21